### PR TITLE
Add Notify URL to FormDirect object

### DIFF
--- a/src/SecuredSigningClientSdk/Models/Data.cs
+++ b/src/SecuredSigningClientSdk/Models/Data.cs
@@ -43,6 +43,11 @@ namespace SecuredSigningClientSdk.Models
 
         [ApiMember(Description = "After signing a form, the page will redirect to the specified url", DataType = SwaggerType.String, IsRequired = false)]
         public string ReturnUrl { get; set; }
+        /// <summary>
+        /// *BETA, Only available in DSX
+        /// </summary>
+        [ApiMember(Description = "Notify Url.", DataType = SwaggerType.String, IsRequired = false)]
+        public string NotifyUrl { get; set; }
 
         [ApiMember(Description = "Auto fill data for the form. It is an XML document converted to a string. Secured Signing creates the template for the data.", DataType = SwaggerType.String, IsRequired = false)]
         public string XMLData { get; set; }

--- a/src/SecuredSigningClientSdk/SecuredSigningClientSdk.nuspec
+++ b/src/SecuredSigningClientSdk/SecuredSigningClientSdk.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>securedsigning.client</id>
-    <version>1.4.20</version>
+    <version>1.4.21</version>
     <title>Secured Signing Rest Client SDK</title>
     <authors>Secured Signing</authors>
     <owners>Secured Signing Ltd</owners>


### PR DESCRIPTION
Adds NotifyURL to FormDirect Object so that Web Hook can be sent back to Integrations when various events occur.